### PR TITLE
Create telegram bot for crypto trading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Telegram Bot Token
+TELEGRAM_TOKEN=
+
+# Bybit API credentials (TRADE only)
+BYBIT_API_KEY=
+BYBIT_API_SECRET=
+
+# Dry run mode: true/false (default true)
+DRY_RUN=true
+
+# Logging
+LOG_LEVEL=INFO
+LOG_FILE=logs/app.log

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ BYBIT_API_SECRET=
 # Dry run mode: true/false (default true)
 DRY_RUN=true
 
+# Base currency for buy buttons and primary pair
+BASE_CURRENCY=USDC
+
 # Logging
 LOG_LEVEL=INFO
 LOG_FILE=logs/app.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-# TGC
+# Minimal Telegram Trading Bot (Bybit Spot)
+
+This bot lets you quickly buy a crypto on Bybit Spot using inline buttons for fixed USDT amounts. It fetches coin info (name + icon) from CoinGecko and places MARKET buy orders via ccxt.
+
+## Features
+- `/buy <ticker>` (e.g., `/buy pepe`)
+- Confirms pair on Bybit (spot), shows full coin name and current price
+- Sends coin icon (from CoinGecko) when available, otherwise a text fallback
+- Inline buttons: [Купить 10 USDT] [Купить 20 USDT] [Отмена]
+- MARKET buy order via Bybit API using ccxt
+- Config from `.env` with DRY_RUN mode (default true)
+- Logging to `logs/app.log` and console
+- Error messages for missing pair and insufficient balance
+
+## Project structure
+```
+/app
+  main.py
+  bot.py
+  exchange.py
+  coingecko.py
+  settings.py
+requirements.txt
+.env.example
+README.md
+```
+
+## Setup
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env  # fill your keys
+python app/main.py
+```
+
+## Configuration
+Set the following in `.env`:
+- `TELEGRAM_TOKEN`: Telegram bot token
+- `BYBIT_API_KEY`, `BYBIT_API_SECRET`: Bybit API keys with TRADE rights only (no withdraw)
+- `DRY_RUN`: `true`/`false` (default `true`). When `true`, orders are simulated
+- `LOG_LEVEL`: default `INFO`
+- `LOG_FILE`: default `logs/app.log`
+
+## Security Notes
+- DRY_RUN defaults to `true`
+- Every order validates the symbol exists in exchange markets first
+- API keys should have only TRADE permissions; no WITHDRAW rights
+
+## Notes
+- Market minimums are respected when available; cost may be adjusted up to the exchange minimum.
+- Insufficient USDT balance is detected and reported before placing a live order.
+- CoinGecko rate limits apply; if icon retrieval fails, the bot falls back to text.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Minimal Telegram Trading Bot (Bybit Spot)
 
-This bot lets you quickly buy a crypto on Bybit Spot using inline buttons for fixed USDT amounts. It fetches coin info (name + icon) from CoinGecko and places MARKET buy orders via ccxt.
+This bot lets you quickly buy a crypto on Bybit Spot using inline buttons for fixed amounts in a base currency (default USDC). It fetches coin info (name + icon) from CoinGecko and places MARKET buy orders via ccxt.
 
 ## Features
 - `/buy <ticker>` (e.g., `/buy pepe`)
 - Confirms pair on Bybit (spot), shows full coin name and current price
 - Sends coin icon (from CoinGecko) when available, otherwise a text fallback
-- Inline buttons: [Купить 10 USDT] [Купить 20 USDT] [Отмена]
+- Inline buttons: [Купить 10 USDC] [Купить 20 USDC] [Отмена]
 - MARKET buy order via Bybit API using ccxt
 - Config from `.env` with DRY_RUN mode (default true)
 - Logging to `logs/app.log` and console
@@ -38,6 +38,7 @@ Set the following in `.env`:
 - `TELEGRAM_TOKEN`: Telegram bot token
 - `BYBIT_API_KEY`, `BYBIT_API_SECRET`: Bybit API keys with TRADE rights only (no withdraw)
 - `DRY_RUN`: `true`/`false` (default `true`). When `true`, orders are simulated
+- `BASE_CURRENCY`: base quote currency for buttons and preferred pair, default `USDC`
 - `LOG_LEVEL`: default `INFO`
 - `LOG_FILE`: default `logs/app.log`
 
@@ -47,6 +48,7 @@ Set the following in `.env`:
 - API keys should have only TRADE permissions; no WITHDRAW rights
 
 ## Notes
+- If `<TICKER>/USDC` exists, the bot buys in USDC. Otherwise it checks USDT balance; if insufficient it converts USDC→USDT via `USDC/USDT` market order, then buys `<TICKER>/USDT`.
 - Market minimums are respected when available; cost may be adjusted up to the exchange minimum.
-- Insufficient USDT balance is detected and reported before placing a live order.
+- Insufficient funds in both USDC and USDT will result in a message with balances.
 - CoinGecko rate limits apply; if icon retrieval fails, the bot falls back to text.

--- a/app/bot.py
+++ b/app/bot.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.ext import (
+    AIORateLimiter,
+    Application,
+    ApplicationBuilder,
+    CallbackQueryHandler,
+    CommandHandler,
+    ContextTypes,
+)
+
+from .coingecko import search_coin_by_ticker
+from .exchange import (
+    BybitClient,
+    ExchangeError,
+    InsufficientFundsError,
+    MarketNotFoundError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+BUY_PREFIX = "BUY_USDT_"
+CANCEL = "CANCEL"
+
+
+def _build_buy_keyboard(amounts: list[int]) -> InlineKeyboardMarkup:
+    buttons = [
+        [InlineKeyboardButton(text=f"Купить {amt} USDT", callback_data=f"{BUY_PREFIX}{amt}")]
+        for amt in amounts
+    ]
+    buttons.append([InlineKeyboardButton(text="Отмена", callback_data=CANCEL)])
+    return InlineKeyboardMarkup(buttons)
+
+
+class TradingBot:
+    def __init__(self, exchange: BybitClient) -> None:
+        self.exchange = exchange
+
+    def build_app(self, token: str) -> Application:
+        app = (
+            ApplicationBuilder()
+            .token(token)
+            .concurrent_updates(True)
+            .rate_limiter(AIORateLimiter())
+            .build()
+        )
+        app.add_handler(CommandHandler("buy", self.cmd_buy))
+        app.add_handler(CallbackQueryHandler(self.on_callback))
+        return app
+
+    async def cmd_buy(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        if update.effective_chat is None:
+            return
+        args = context.args or []
+        if not args:
+            await update.effective_chat.send_message(
+                "Использование: /buy <ticker> — например /buy pepe"
+            )
+            return
+        ticker = args[0]
+        symbol = self.exchange.normalize_symbol(ticker)
+
+        # Ensure markets are loaded to check availability
+        try:
+            await self.exchange.load_markets()
+            await self.exchange.ensure_market(symbol)
+        except MarketNotFoundError:
+            await update.effective_chat.send_message(
+                f"Пара не найдена на Bybit (спот): {symbol}"
+            )
+            return
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Failed to load markets: %s", exc)
+            await update.effective_chat.send_message("Ошибка при загрузке рынков")
+            return
+
+        # Fetch coin info and price
+        coin = await search_coin_by_ticker(ticker)
+        try:
+            price = await self.exchange.get_ticker_price(symbol)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Failed to fetch price: %s", exc)
+            await update.effective_chat.send_message("Ошибка при получении цены")
+            return
+
+        title = (
+            f"Найдена пара {symbol}.\n"
+            f"Монета: {(coin.name if coin else ticker.upper())}\n"
+            f"Цена: {price:.6f} USDT"
+        )
+
+        keyboard = _build_buy_keyboard([10, 20])
+
+        if coin and coin.thumb:
+            try:
+                await update.effective_chat.send_photo(
+                    photo=coin.thumb,
+                    caption=title,
+                    reply_markup=keyboard,
+                )
+                return
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Sending photo failed, fallback to text: %s", exc)
+
+        await update.effective_chat.send_message(text=title, reply_markup=keyboard)
+
+        # Store context for callbacks (per-chat)
+        context.chat_data["symbol"] = symbol
+
+    async def on_callback(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        query = update.callback_query
+        if not query:
+            return
+        await query.answer()
+
+        data = query.data or ""
+        if data == CANCEL:
+            await query.edit_message_reply_markup(reply_markup=None)
+            await query.message.reply_text("Отменено")
+            return
+
+        if not data.startswith(BUY_PREFIX):
+            return
+
+        amount_str = data[len(BUY_PREFIX) :]
+        try:
+            usdt_amount = float(amount_str)
+        except ValueError:
+            await query.message.reply_text("Некорректная сумма")
+            return
+
+        symbol = context.chat_data.get("symbol")
+        if not symbol:
+            await query.message.reply_text("Не найден контекст для покупки. Повторите /buy")
+            return
+
+        try:
+            result = await self.exchange.market_buy_for_cost(symbol, usdt_amount)
+        except InsufficientFundsError as exc:
+            await query.message.reply_text(str(exc))
+            return
+        except MarketNotFoundError:
+            await query.message.reply_text("Пара больше недоступна")
+            return
+        except ExchangeError as exc:
+            logger.exception("Exchange error: %s", exc)
+            await query.message.reply_text("Ошибка биржи: не удалось выполнить ордер")
+            return
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Unexpected error: %s", exc)
+            await query.message.reply_text("Неизвестная ошибка")
+            return
+
+        msg = (
+            f"Ордер BUY выполнен (режим: {'DRY_RUN' if self.exchange.dry_run else 'LIVE'}).\n"
+            f"Пара: {result.symbol}\n"
+            f"Цена: {result.price if result.price is not None else '—'}\n"
+            f"Кол-во: {result.amount if result.amount is not None else '—'}\n"
+            f"Стоимость: {result.cost if result.cost is not None else '—'} USDT\n"
+            f"Статус: {result.status}"
+        )
+        await query.message.reply_text(msg)

--- a/app/bot.py
+++ b/app/bot.py
@@ -20,17 +20,18 @@ from .exchange import (
     InsufficientFundsError,
     MarketNotFoundError,
 )
+from .settings import Settings
 
 logger = logging.getLogger(__name__)
 
 
-BUY_PREFIX = "BUY_USDT_"
+BUY_PREFIX = "BUY_"
 CANCEL = "CANCEL"
 
 
-def _build_buy_keyboard(amounts: list[int]) -> InlineKeyboardMarkup:
+def _build_buy_keyboard(amounts: list[int], currency: str) -> InlineKeyboardMarkup:
     buttons = [
-        [InlineKeyboardButton(text=f"Купить {amt} USDT", callback_data=f"{BUY_PREFIX}{amt}")]
+        [InlineKeyboardButton(text=f"Купить {amt} {currency}", callback_data=f"{BUY_PREFIX}{amt}")]
         for amt in amounts
     ]
     buttons.append([InlineKeyboardButton(text="Отмена", callback_data=CANCEL)])
@@ -38,8 +39,9 @@ def _build_buy_keyboard(amounts: list[int]) -> InlineKeyboardMarkup:
 
 
 class TradingBot:
-    def __init__(self, exchange: BybitClient) -> None:
+    def __init__(self, exchange: BybitClient, settings: Settings) -> None:
         self.exchange = exchange
+        self.settings = settings
 
     def build_app(self, token: str) -> Application:
         app = (
@@ -63,17 +65,19 @@ class TradingBot:
             )
             return
         ticker = args[0]
-        symbol = self.exchange.normalize_symbol(ticker)
+        base_quote = self.settings.base_currency
+        symbol_usdc = self.exchange.symbol_with_quote(ticker, "USDC")
+        symbol_usdt = self.exchange.symbol_with_quote(ticker, "USDT")
 
         # Ensure markets are loaded to check availability
         try:
             await self.exchange.load_markets()
-            await self.exchange.ensure_market(symbol)
+            await self.exchange.ensure_market(symbol_usdc)
+            chosen_symbol = symbol_usdc
+            chosen_quote = "USDC"
         except MarketNotFoundError:
-            await update.effective_chat.send_message(
-                f"Пара не найдена на Bybit (спот): {symbol}"
-            )
-            return
+            chosen_symbol = symbol_usdt
+            chosen_quote = "USDT"
         except Exception as exc:  # noqa: BLE001
             logger.exception("Failed to load markets: %s", exc)
             await update.effective_chat.send_message("Ошибка при загрузке рынков")
@@ -82,19 +86,19 @@ class TradingBot:
         # Fetch coin info and price
         coin = await search_coin_by_ticker(ticker)
         try:
-            price = await self.exchange.get_ticker_price(symbol)
+            price = await self.exchange.get_ticker_price(chosen_symbol)
         except Exception as exc:  # noqa: BLE001
             logger.exception("Failed to fetch price: %s", exc)
             await update.effective_chat.send_message("Ошибка при получении цены")
             return
 
         title = (
-            f"Найдена пара {symbol}.\n"
+            f"Найдена пара {chosen_symbol}.\n"
             f"Монета: {(coin.name if coin else ticker.upper())}\n"
-            f"Цена: {price:.6f} USDT"
+            f"Цена: {price:.6f} {chosen_quote}"
         )
 
-        keyboard = _build_buy_keyboard([10, 20])
+        keyboard = _build_buy_keyboard([10, 20], self.settings.base_currency)
 
         if coin and coin.thumb:
             try:
@@ -110,7 +114,10 @@ class TradingBot:
         await update.effective_chat.send_message(text=title, reply_markup=keyboard)
 
         # Store context for callbacks (per-chat)
-        context.chat_data["symbol"] = symbol
+        context.chat_data["symbol_usdc"] = symbol_usdc
+        context.chat_data["symbol_usdt"] = symbol_usdt
+        context.chat_data["chosen_symbol"] = chosen_symbol
+        context.chat_data["chosen_quote"] = chosen_quote
 
     async def on_callback(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         query = update.callback_query
@@ -129,18 +136,68 @@ class TradingBot:
 
         amount_str = data[len(BUY_PREFIX) :]
         try:
-            usdt_amount = float(amount_str)
+            base_amount = float(amount_str)
         except ValueError:
             await query.message.reply_text("Некорректная сумма")
             return
 
-        symbol = context.chat_data.get("symbol")
-        if not symbol:
+        symbol_usdc = context.chat_data.get("symbol_usdc")
+        symbol_usdt = context.chat_data.get("symbol_usdt")
+        chosen_symbol = context.chat_data.get("chosen_symbol")
+        chosen_quote = context.chat_data.get("chosen_quote")
+        if not symbol_usdc or not symbol_usdt or not chosen_symbol or not chosen_quote:
             await query.message.reply_text("Не найден контекст для покупки. Повторите /buy")
             return
 
+        # Determine execution flow:
+        log_steps: list[str] = []
         try:
-            result = await self.exchange.market_buy_for_cost(symbol, usdt_amount)
+            if chosen_quote == "USDC":
+                # Verify USDC balance
+                usdc_balance = await self.exchange.get_usdc_balance()
+                if usdc_balance + 1e-8 < base_amount:
+                    usdt_balance = await self.exchange.get_usdt_balance()
+                    msg = (
+                        f"Недостаточно средств (баланс USDC/USDT: {usdc_balance:.2f}/{usdt_balance:.2f})"
+                    )
+                    logger.info(msg)
+                    await query.message.reply_text(msg)
+                    return
+                # Buy directly with USDC
+                result = await self.exchange.market_buy_for_cost(symbol_usdc, base_amount)
+                spent_text = f"Списано {result.cost:.2f} USDC"
+            else:
+                # chosen_quote == "USDT"; compute target USDT cost equivalent to base_amount USDC
+                conv_price = await self.exchange.get_ticker_price("USDC/USDT")
+                target_usdt_cost = base_amount * conv_price
+                usdt_balance = await self.exchange.get_usdt_balance()
+                usdc_balance = await self.exchange.get_usdc_balance()
+
+                total_usdt_equiv = usdt_balance + usdc_balance * conv_price
+                if total_usdt_equiv + 1e-8 < target_usdt_cost:
+                    msg = (
+                        f"Недостаточно средств (баланс USDC/USDT: {usdc_balance:.2f}/{usdt_balance:.2f})"
+                    )
+                    logger.info(msg)
+                    await query.message.reply_text(msg)
+                    return
+
+                if usdt_balance + 1e-8 < target_usdt_cost:
+                    need_usdt = target_usdt_cost - usdt_balance
+                    # Estimate required USDC with 0.3% buffer
+                    usdc_needed = need_usdt / max(conv_price, 1e-12) * 1.003
+                    usdc_needed = min(usdc_needed, usdc_balance)
+                    conv_order, received_usdt = await self.exchange.convert_usdc_to_usdt(usdc_needed)
+                    step = (
+                        f"Обменял {conv_order.amount:.2f} USDC на {received_usdt:.2f} USDT"
+                        if not self.exchange.dry_run
+                        else f"[DRY_RUN] Обменял бы {usdc_needed:.2f} USDC на ~{received_usdt:.2f} USDT"
+                    )
+                    log_steps.append(step)
+                    logger.info(step)
+                # Now buy with USDT for the USDC-equivalent target cost
+                result = await self.exchange.market_buy_for_cost(symbol_usdt, target_usdt_cost)
+                spent_text = f"Списано {result.cost:.2f} USDT"
         except InsufficientFundsError as exc:
             await query.message.reply_text(str(exc))
             return
@@ -156,12 +213,12 @@ class TradingBot:
             await query.message.reply_text("Неизвестная ошибка")
             return
 
+        steps_text = "\n".join(log_steps)
         msg = (
-            f"Ордер BUY выполнен (режим: {'DRY_RUN' if self.exchange.dry_run else 'LIVE'}).\n"
-            f"Пара: {result.symbol}\n"
-            f"Цена: {result.price if result.price is not None else '—'}\n"
-            f"Кол-во: {result.amount if result.amount is not None else '—'}\n"
-            f"Стоимость: {result.cost if result.cost is not None else '—'} USDT\n"
-            f"Статус: {result.status}"
+            f"Режим: {'DRY_RUN' if self.exchange.dry_run else 'LIVE'}\n"
+            + (steps_text + "\n" if steps_text else "")
+            + f"Куплено {result.amount if result.amount is not None else '—'} {result.symbol.split('/')[0]} по цене {result.price if result.price is not None else '—'} {result.symbol.split('/')[1]}\n"
+            + spent_text + "\n"
+            + f"Статус: {result.status}"
         )
         await query.message.reply_text(msg)

--- a/app/coingecko.py
+++ b/app/coingecko.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+COINGECKO_API = "https://api.coingecko.com/api/v3"
+
+
+@dataclass
+class CoinInfo:
+    id: str
+    symbol: str
+    name: str
+    thumb: Optional[str]
+
+
+async def search_coin_by_ticker(ticker: str) -> Optional[CoinInfo]:
+    query = ticker.strip().lower()
+    if not query:
+        return None
+
+    url = f"{COINGECKO_API}/search?query={query}"
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            resp = await client.get(url)
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("CoinGecko search failed: %s", exc)
+            return None
+
+    coins = (data or {}).get("coins") or []
+    if not coins:
+        return None
+
+    # Prefer exact symbol match; fallback to first result
+    exact = next((c for c in coins if c.get("symbol", "").lower() == query), None)
+    selected = exact or coins[0]
+
+    return CoinInfo(
+        id=str(selected.get("id")),
+        symbol=str(selected.get("symbol")),
+        name=str(selected.get("name")),
+        thumb=selected.get("thumb"),
+    )

--- a/app/exchange.py
+++ b/app/exchange.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Tuple
 
 import ccxt.async_support as ccxt
 
@@ -50,9 +50,9 @@ class BybitClient:
     async def load_markets(self) -> None:
         await self.exchange.load_markets()
 
-    def normalize_symbol(self, ticker: str) -> str:
+    def symbol_with_quote(self, ticker: str, quote: str) -> str:
         base = ticker.strip().upper()
-        return f"{base}/USDT"
+        return f"{base}/{quote.strip().upper()}"
 
     def has_market(self, symbol: str) -> bool:
         return symbol in self.exchange.markets
@@ -75,40 +75,58 @@ class BybitClient:
             )
         return float(usdt or 0.0)
 
-    async def market_buy_for_cost(self, symbol: str, usdt_cost: float) -> OrderResult:
+    async def get_usdc_balance(self) -> float:
+        balance = await self.exchange.fetch_balance()
+        usdc = balance.get("free", {}).get("USDC")
+        if usdc is None:
+            usdc = (balance.get("total", {}) or {}).get("USDC", 0) - (
+                (balance.get("used", {}) or {}).get("USDC", 0)
+            )
+        return float(usdc or 0.0)
+
+    async def market_buy_for_cost(self, symbol: str, quote_cost: float) -> OrderResult:
         await self.ensure_market(symbol)
 
         if self.dry_run:
             logger.info("DRY_RUN is enabled; not placing real order")
             price = await self.get_ticker_price(symbol)
-            amount = usdt_cost / price if price > 0 else None
+            amount = quote_cost / price if price > 0 else None
             return OrderResult(
                 id="dry-run",
                 symbol=symbol,
                 side="buy",
                 price=price,
                 amount=amount,
-                cost=usdt_cost,
+                cost=quote_cost,
                 status="simulated",
             )
 
-        balance = await self.get_usdt_balance()
-        if balance + 1e-8 < usdt_cost:
+        # Validate we have enough of the quote currency; caller should ensure
+        # conversion if needed.
+        quote = symbol.split("/")[-1]
+        if quote == "USDT":
+            balance = await self.get_usdt_balance()
+        elif quote == "USDC":
+            balance = await self.get_usdc_balance()
+        else:
+            balance = 0.0
+
+        if balance + 1e-8 < quote_cost:
             raise InsufficientFundsError(
-                f"Insufficient USDT balance: have {balance:.4f}, need {usdt_cost:.4f}"
+                f"Insufficient {quote} balance: have {balance:.4f}, need {quote_cost:.4f}"
             )
 
         price = await self.get_ticker_price(symbol)
         min_cost = self._min_cost_for_symbol(symbol)
-        if min_cost and usdt_cost < min_cost:
+        if min_cost and quote_cost < min_cost:
             logger.info(
                 "Adjusting cost to exchange minimum: requested=%s, min=%s",
-                usdt_cost,
+                quote_cost,
                 min_cost,
             )
-            usdt_cost = min_cost
+            quote_cost = min_cost
 
-        amount = usdt_cost / price if price > 0 else None
+        amount = quote_cost / price if price > 0 else None
         if not amount or amount <= 0:
             raise ExchangeError("Calculated amount is invalid")
 
@@ -120,8 +138,67 @@ class BybitClient:
             side=order.get("side", "buy"),
             price=float(order.get("average") or order.get("price") or price or 0.0),
             amount=float(order.get("amount") or amount or 0.0),
-            cost=float(order.get("cost") or usdt_cost or 0.0),
+            cost=float(order.get("cost") or quote_cost or 0.0),
             status=str(order.get("status") or "unknown"),
+        )
+
+    async def convert_usdc_to_usdt(self, usdc_amount: float) -> Tuple[OrderResult, float]:
+        """Convert USDC to USDT via market sell on USDC/USDT.
+
+        Returns tuple of (order_result, received_usdt_estimate).
+        In DRY_RUN, simulates using ticker price.
+        """
+        symbol = "USDC/USDT"
+        await self.ensure_market(symbol)
+
+        if usdc_amount <= 0:
+            raise ExchangeError("Conversion amount must be > 0")
+
+        if self.dry_run:
+            price = await self.get_ticker_price(symbol)  # price in USDT per USDC
+            received = usdc_amount * price
+            logger.info("DRY_RUN: would convert %.4f USDC -> %.4f USDT at ~%.6f", usdc_amount, received, price)
+            return (
+                OrderResult(
+                    id="dry-run",
+                    symbol=symbol,
+                    side="sell",
+                    price=price,
+                    amount=usdc_amount,
+                    cost=received,
+                    status="simulated",
+                ),
+                received,
+            )
+
+        # Ensure enough USDC
+        usdc_balance = await self.get_usdc_balance()
+        if usdc_balance + 1e-8 < usdc_amount:
+            raise InsufficientFundsError(
+                f"Insufficient USDC balance: have {usdc_balance:.4f}, need {usdc_amount:.4f}"
+            )
+
+        price = await self.get_ticker_price(symbol)
+        min_cost = self._min_cost_for_symbol(symbol)
+        # For sell USDC/USDT, cost limit is in quote (USDT); we approximate with amount*price
+        if min_cost and usdc_amount * price < min_cost:
+            adj = min_cost / max(price, 1e-12)
+            logger.info("Adjusting USDC sell to min cost: requested=%s, min_amount=%s", usdc_amount, adj)
+            usdc_amount = adj
+
+        order = await self.exchange.create_order(symbol, "market", "sell", usdc_amount)
+        received = float(order.get("cost") or (usdc_amount * price))
+        return (
+            OrderResult(
+                id=str(order.get("id")),
+                symbol=order.get("symbol", symbol),
+                side=order.get("side", "sell"),
+                price=float(order.get("average") or order.get("price") or price or 0.0),
+                amount=float(order.get("amount") or usdc_amount or 0.0),
+                cost=received,
+                status=str(order.get("status") or "unknown"),
+            ),
+            received,
         )
 
     def _min_cost_for_symbol(self, symbol: str) -> float | None:

--- a/app/exchange.py
+++ b/app/exchange.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+import ccxt.async_support as ccxt
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OrderResult:
+    id: str
+    symbol: str
+    side: str
+    price: float | None
+    amount: float | None
+    cost: float | None
+    status: str | None
+
+
+class ExchangeError(Exception):
+    pass
+
+
+class InsufficientFundsError(ExchangeError):
+    pass
+
+
+class MarketNotFoundError(ExchangeError):
+    pass
+
+
+class BybitClient:
+    def __init__(
+        self,
+        api_key: Optional[str],
+        api_secret: Optional[str],
+        dry_run: bool = True,
+    ) -> None:
+        self.dry_run = dry_run
+        self.exchange = ccxt.bybit({
+            "apiKey": api_key or "",
+            "secret": api_secret or "",
+            "options": {"defaultType": "spot"},
+            "enableRateLimit": True,
+        })
+
+    async def load_markets(self) -> None:
+        await self.exchange.load_markets()
+
+    def normalize_symbol(self, ticker: str) -> str:
+        base = ticker.strip().upper()
+        return f"{base}/USDT"
+
+    def has_market(self, symbol: str) -> bool:
+        return symbol in self.exchange.markets
+
+    async def ensure_market(self, symbol: str) -> None:
+        if not self.has_market(symbol):
+            raise MarketNotFoundError(f"Market not found: {symbol}")
+
+    async def get_ticker_price(self, symbol: str) -> float:
+        ticker = await self.exchange.fetch_ticker(symbol)
+        return float(ticker.get("last") or ticker.get("close") or 0.0)
+
+    async def get_usdt_balance(self) -> float:
+        balance = await self.exchange.fetch_balance()
+        usdt = balance.get("free", {}).get("USDT")
+        if usdt is None:
+            # Some exchanges return structure under total/free
+            usdt = (balance.get("total", {}) or {}).get("USDT", 0) - (
+                (balance.get("used", {}) or {}).get("USDT", 0)
+            )
+        return float(usdt or 0.0)
+
+    async def market_buy_for_cost(self, symbol: str, usdt_cost: float) -> OrderResult:
+        await self.ensure_market(symbol)
+
+        if self.dry_run:
+            logger.info("DRY_RUN is enabled; not placing real order")
+            price = await self.get_ticker_price(symbol)
+            amount = usdt_cost / price if price > 0 else None
+            return OrderResult(
+                id="dry-run",
+                symbol=symbol,
+                side="buy",
+                price=price,
+                amount=amount,
+                cost=usdt_cost,
+                status="simulated",
+            )
+
+        balance = await self.get_usdt_balance()
+        if balance + 1e-8 < usdt_cost:
+            raise InsufficientFundsError(
+                f"Insufficient USDT balance: have {balance:.4f}, need {usdt_cost:.4f}"
+            )
+
+        price = await self.get_ticker_price(symbol)
+        min_cost = self._min_cost_for_symbol(symbol)
+        if min_cost and usdt_cost < min_cost:
+            logger.info(
+                "Adjusting cost to exchange minimum: requested=%s, min=%s",
+                usdt_cost,
+                min_cost,
+            )
+            usdt_cost = min_cost
+
+        amount = usdt_cost / price if price > 0 else None
+        if not amount or amount <= 0:
+            raise ExchangeError("Calculated amount is invalid")
+
+        # Place market order in quote currency by sizing base amount.
+        order = await self.exchange.create_order(symbol, "market", "buy", amount)
+        return OrderResult(
+            id=str(order.get("id")),
+            symbol=order.get("symbol", symbol),
+            side=order.get("side", "buy"),
+            price=float(order.get("average") or order.get("price") or price or 0.0),
+            amount=float(order.get("amount") or amount or 0.0),
+            cost=float(order.get("cost") or usdt_cost or 0.0),
+            status=str(order.get("status") or "unknown"),
+        )
+
+    def _min_cost_for_symbol(self, symbol: str) -> float | None:
+        market = self.exchange.markets.get(symbol)
+        if not market:
+            return None
+        # Bybit spot often exposes limits with cost or amount and price precision
+        limits = market.get("limits") or {}
+        cost_limit = limits.get("cost") or {}
+        min_cost = cost_limit.get("min")
+        return float(min_cost) if min_cost else None

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from app.bot import TradingBot
+from app.exchange import BybitClient
+from app.settings import load_settings, setup_logging
+
+
+async def main_async() -> None:
+    settings = load_settings()
+    setup_logging(settings.log_level, settings.log_file)
+    logger = logging.getLogger(__name__)
+
+    logger.info("Starting bot (dry_run=%s)", settings.dry_run)
+
+    exchange = BybitClient(
+        api_key=settings.bybit_api_key,
+        api_secret=settings.bybit_api_secret,
+        dry_run=settings.dry_run,
+    )
+
+    bot = TradingBot(exchange)
+    app = bot.build_app(settings.telegram_token)
+
+    await app.initialize()
+    await app.start()
+    try:
+        await app.updater.start_polling(drop_pending_updates=True)
+        await asyncio.Event().wait()  # run forever
+    finally:
+        await app.updater.stop()
+        await app.stop()
+        await app.shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(main_async())

--- a/app/main.py
+++ b/app/main.py
@@ -21,7 +21,7 @@ async def main_async() -> None:
         dry_run=settings.dry_run,
     )
 
-    bot = TradingBot(exchange)
+    bot = TradingBot(exchange, settings)
     app = bot.build_app(settings.telegram_token)
 
     await app.initialize()

--- a/app/settings.py
+++ b/app/settings.py
@@ -15,6 +15,7 @@ class Settings:
     bybit_api_key: str | None
     bybit_api_secret: str | None
     dry_run: bool
+    base_currency: str
     log_level: str
     log_file: str
 
@@ -33,6 +34,7 @@ def load_settings() -> Settings:
     bybit_api_key = os.getenv("BYBIT_API_KEY")
     bybit_api_secret = os.getenv("BYBIT_API_SECRET")
     dry_run = _str_to_bool(os.getenv("DRY_RUN"), True)
+    base_currency = os.getenv("BASE_CURRENCY", "USDC").strip().upper() or "USDC"
     log_level = os.getenv("LOG_LEVEL", "INFO").upper()
     log_file = os.getenv("LOG_FILE", "logs/app.log")
 
@@ -44,6 +46,7 @@ def load_settings() -> Settings:
         bybit_api_key=bybit_api_key,
         bybit_api_secret=bybit_api_secret,
         dry_run=dry_run,
+        base_currency=base_currency,
         log_level=log_level,
         log_file=log_file,
     )

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import logging
+import logging.handlers
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+@dataclass(frozen=True)
+class Settings:
+    telegram_token: str
+    bybit_api_key: str | None
+    bybit_api_secret: str | None
+    dry_run: bool
+    log_level: str
+    log_file: str
+
+
+def _str_to_bool(value: str | None, default: bool) -> bool:
+    if value is None or value == "":
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def load_settings() -> Settings:
+    # Load .env if present
+    load_dotenv()
+
+    telegram_token = os.getenv("TELEGRAM_TOKEN", "").strip()
+    bybit_api_key = os.getenv("BYBIT_API_KEY")
+    bybit_api_secret = os.getenv("BYBIT_API_SECRET")
+    dry_run = _str_to_bool(os.getenv("DRY_RUN"), True)
+    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+    log_file = os.getenv("LOG_FILE", "logs/app.log")
+
+    if not telegram_token:
+        raise RuntimeError("TELEGRAM_TOKEN is required")
+
+    return Settings(
+        telegram_token=telegram_token,
+        bybit_api_key=bybit_api_key,
+        bybit_api_secret=bybit_api_secret,
+        dry_run=dry_run,
+        log_level=log_level,
+        log_file=log_file,
+    )
+
+
+def setup_logging(log_level: str, log_file: str) -> None:
+    Path(log_file).parent.mkdir(parents=True, exist_ok=True)
+
+    level = getattr(logging, log_level.upper(), logging.INFO)
+
+    formatter = logging.Formatter(
+        fmt="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+
+    # Console handler
+    console = logging.StreamHandler()
+    console.setLevel(level)
+    console.setFormatter(formatter)
+
+    # File handler (rotating)
+    file_handler = logging.handlers.RotatingFileHandler(
+        log_file, maxBytes=5 * 1024 * 1024, backupCount=2, encoding="utf-8"
+    )
+    file_handler.setLevel(level)
+    file_handler.setFormatter(formatter)
+
+    # Clear existing handlers to avoid duplication on reload
+    for h in list(root_logger.handlers):
+        root_logger.removeHandler(h)
+
+    root_logger.addHandler(console)
+    root_logger.addHandler(file_handler)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+python-telegram-bot==21.4
+ccxt==4.3.91
+python-dotenv==1.0.1
+httpx==0.27.2
+pydantic==2.9.2


### PR DESCRIPTION
Implement a minimal Telegram bot for Bybit spot trading with `/buy` command, CoinGecko integration, and market buy order execution.

---
<a href="https://cursor.com/background-agent?bcId=bc-4b1af8cb-3fda-4be9-b2ea-77779969625b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4b1af8cb-3fda-4be9-b2ea-77779969625b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

