### PR TITLE
Update bot for usdc base currency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Telegram
+TELEGRAM_TOKEN=
+
+# Bybit API (spot)
+BYBIT_API_KEY=
+BYBIT_SECRET=
+
+# Behavior
+BASE_CURRENCY=USDC
+DRY_RUN=true
+
+# Logging
+LOG_FILE=logs/bot.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.venv/
+.env
+logs/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# TGC
+## Telegram bot with USDC base currency on Bybit
+
+Run:
+
+1. Create `.env` from `.env.example` and fill in `TELEGRAM_TOKEN`, `BYBIT_API_KEY`, `BYBIT_SECRET`.
+2. Install deps:
+
+```bash
+pip3 install -r requirements.txt
+```
+
+3. Start bot:
+
+```bash
+python3 -m bot.main
+```
+
+Features:
+- Prefer `<TICKER>/USDC`; fallback to `<TICKER>/USDT` with auto USDC→USDT conversion
+- DRY_RUN mode prints intended actions
+- Detailed logging to `logs/bot.log`

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
+
+@dataclass
+class Settings:
+    telegram_token: str
+    bybit_api_key: str
+    bybit_secret: str
+    dry_run: bool
+    base_currency: str
+    log_file: str
+
+
+def str_to_bool(value: str | None, default: bool = False) -> bool:
+    if value is None:
+        return default
+    lowered = value.strip().lower()
+    if lowered in {"1", "true", "yes", "y", "on"}:
+        return True
+    if lowered in {"0", "false", "no", "n", "off"}:
+        return False
+    return default
+
+
+def get_settings() -> Settings:
+    return Settings(
+        telegram_token=os.getenv("TELEGRAM_TOKEN", ""),
+        bybit_api_key=os.getenv("BYBIT_API_KEY", ""),
+        bybit_secret=os.getenv("BYBIT_SECRET", ""),
+        dry_run=str_to_bool(os.getenv("DRY_RUN"), default=False),
+        base_currency=os.getenv("BASE_CURRENCY", "USDC").upper(),
+        log_file=os.getenv("LOG_FILE", "logs/bot.log"),
+    )

--- a/app/exchange.py
+++ b/app/exchange.py
@@ -117,8 +117,9 @@ class ExchangeService:
         if direct:
             price = self.fetch_ticker_price(direct.symbol)
             base_amount = self.round_to_precision(from_amount, direct.amount_precision)
+            verb = "Обменял бы" if self.dry_run else "Обменял"
             text = (
-                f"Обменял {self.round_to_precision(base_amount, 6)} {from_cur} на ~"
+                f"{verb} {self.round_to_precision(base_amount, 6)} {from_cur} на ~"
                 f"{self.round_to_precision(base_amount * price, 6)} {to_cur} по цене ~"
                 f"{self.round_to_precision(price, direct.price_precision)} {to_cur}"
             )
@@ -133,8 +134,9 @@ class ExchangeService:
             price = self.fetch_ticker_price(inverse.symbol)  # price in FROM per 1 TO
             # We will BUY base=to_cur spending from_amount of quote=from_cur
             base_amount = self.round_to_precision(from_amount / price, inverse.amount_precision)
+            verb = "Обменял бы" if self.dry_run else "Обменял"
             text = (
-                f"Обменял ~{self.round_to_precision(from_amount, 6)} {from_cur} на "
+                f"{verb} ~{self.round_to_precision(from_amount, 6)} {from_cur} на "
                 f"{self.round_to_precision(base_amount, 6)} {to_cur} по цене ~"
                 f"{self.round_to_precision(price, inverse.price_precision)} {from_cur}"
             )

--- a/app/exchange.py
+++ b/app/exchange.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple, List
+
+import ccxt
+from loguru import logger
+
+
+@dataclass
+class MarketInfo:
+    symbol: str
+    quote: str
+    base: str
+    price_precision: int
+    amount_precision: int
+    min_cost: Optional[float]
+
+
+class ExchangeService:
+    def __init__(self, api_key: str, secret: str, dry_run: bool = False) -> None:
+        self.client = ccxt.bybit({
+            "apiKey": api_key,
+            "secret": secret,
+            "enableRateLimit": True,
+            "options": {"defaultType": "spot"},
+        })
+        self.dry_run = dry_run
+
+    async def load_markets(self) -> None:
+        await self.client.load_markets()
+
+    def get_balance(self) -> Dict[str, float]:
+        bal = self.client.fetch_balance()
+        total: Dict[str, float] = {}
+        for cur, obj in bal.get("total", {}).items():
+            try:
+                total[cur.upper()] = float(obj)
+            except Exception:
+                pass
+        # Also include free balances
+        for cur, obj in bal.get("free", {}).items():
+            try:
+                total[cur.upper()] = float(obj)
+            except Exception:
+                pass
+        return total
+
+    def find_market(self, base: str, quote: str) -> Optional[MarketInfo]:
+        symbol = f"{base}/{quote}"
+        markets = self.client.markets
+        if symbol not in markets:
+            return None
+        m = markets[symbol]
+        price_prec = m.get("precision", {}).get("price", 8)
+        amount_prec = m.get("precision", {}).get("amount", 8)
+        min_cost = None
+        if "limits" in m and "cost" in m["limits"] and m["limits"]["cost"].get("min"):
+            min_cost = float(m["limits"]["cost"]["min"])  # quote currency
+        return MarketInfo(
+            symbol=symbol,
+            quote=m.get("quote"),
+            base=m.get("base"),
+            price_precision=price_prec,
+            amount_precision=amount_prec,
+            min_cost=min_cost,
+        )
+
+    def round_to_precision(self, value: float, precision: int) -> float:
+        if precision <= 0:
+            return float(int(value))
+        factor = 10 ** precision
+        return math.floor(value * factor) / factor
+
+    def fetch_ticker_price(self, symbol: str) -> float:
+        t = self.client.fetch_ticker(symbol)
+        # use last price fallback
+        price = t.get("last") or t.get("close") or t.get("ask") or t.get("bid")
+        return float(price)
+
+    def create_market_order(self, symbol: str, side: str, amount: float) -> Dict:
+        logger.info(f"Create market order: {side} {amount} {symbol}")
+        if self.dry_run:
+            return {
+                "status": "dry_run",
+                "symbol": symbol,
+                "side": side,
+                "amount": amount,
+            }
+        return self.client.create_order(symbol, type="market", side=side, amount=amount)
+
+    def market_buy_by_quote(self, market: MarketInfo, quote_amount: float) -> Tuple[Dict, float, float]:
+        price = self.fetch_ticker_price(market.symbol)
+        amount = quote_amount / price
+        amount = self.round_to_precision(amount, market.amount_precision)
+        if market.min_cost and quote_amount < market.min_cost:
+            raise ValueError(f"Min cost for {market.symbol} is {market.min_cost}")
+        order = self.create_market_order(market.symbol, "buy", amount)
+        return order, amount, price
+
+    def convert_currency(self, from_cur: str, to_cur: str, from_amount: float) -> Tuple[List[str], float, float]:
+        """Convert between currencies using available spot market.
+
+        Returns (steps, received_to_amount, used_price)
+        """
+        steps: List[str] = []
+        from_cur = from_cur.upper()
+        to_cur = to_cur.upper()
+        if from_amount <= 0:
+            return steps, 0.0, 0.0
+
+        # Prefer direct pair FROM/TO with side=sell
+        direct = self.find_market(from_cur, to_cur)
+        inverse = self.find_market(to_cur, from_cur) if not direct else None
+
+        if direct:
+            price = self.fetch_ticker_price(direct.symbol)
+            base_amount = self.round_to_precision(from_amount, direct.amount_precision)
+            text = (
+                f"Обменял {self.round_to_precision(base_amount, 6)} {from_cur} на ~"
+                f"{self.round_to_precision(base_amount * price, 6)} {to_cur} по цене ~"
+                f"{self.round_to_precision(price, direct.price_precision)} {to_cur}"
+            )
+            steps.append(text)
+            if not self.dry_run:
+                self.create_market_order(direct.symbol, "sell", base_amount)
+            else:
+                steps.append("DRY_RUN: ордер на конвертацию не исполнен")
+            return steps, base_amount * price, price
+
+        if inverse:
+            price = self.fetch_ticker_price(inverse.symbol)  # price in FROM per 1 TO
+            # We will BUY base=to_cur spending from_amount of quote=from_cur
+            base_amount = self.round_to_precision(from_amount / price, inverse.amount_precision)
+            text = (
+                f"Обменял ~{self.round_to_precision(from_amount, 6)} {from_cur} на "
+                f"{self.round_to_precision(base_amount, 6)} {to_cur} по цене ~"
+                f"{self.round_to_precision(price, inverse.price_precision)} {from_cur}"
+            )
+            steps.append(text)
+            if not self.dry_run:
+                self.create_market_order(inverse.symbol, "buy", base_amount)
+            else:
+                steps.append("DRY_RUN: ордер на конвертацию не исполнен")
+            return steps, base_amount, price
+
+        raise RuntimeError(f"Рынок для конвертации {from_cur}->{to_cur} не найден")
+
+    def ensure_usdt_for_purchase(self, desired_usdc: float) -> Tuple[List[str], float]:
+        """Ensure we have enough USDT equivalent to desired_usdc amount.
+
+        Returns (steps, available_in_usdt)
+        """
+        steps: List[str] = []
+        balances = self.get_balance()
+        usdc = balances.get("USDC", 0.0)
+        usdt = balances.get("USDT", 0.0)
+
+        if usdt >= desired_usdc:
+            return steps, desired_usdc
+
+        shortfall = max(0.0, desired_usdc - usdt)
+        if shortfall <= 0:
+            return steps, desired_usdc
+
+        convert_amount = min(usdc, shortfall)
+        if convert_amount <= 0:
+            return steps, usdt
+
+        conv_steps, received_usdt, price = self.convert_currency("USDC", "USDT", convert_amount)
+        for s in conv_steps:
+            logger.info(s)
+        steps.extend(conv_steps)
+        return steps, min(desired_usdc, usdt + received_usdt)
+
+    def ensure_usdc_for_purchase(self, desired_usdc: float) -> Tuple[List[str], float]:
+        """Ensure we have enough USDC to spend desired_usdc on a USDC-quoted pair.
+
+        Returns (steps, available_in_usdc)
+        """
+        steps: List[str] = []
+        balances = self.get_balance()
+        usdc = balances.get("USDC", 0.0)
+        usdt = balances.get("USDT", 0.0)
+
+        if usdc >= desired_usdc:
+            return steps, desired_usdc
+
+        shortfall = max(0.0, desired_usdc - usdc)
+        if shortfall <= 0:
+            return steps, desired_usdc
+
+        convert_amount = min(usdt, shortfall)
+        if convert_amount <= 0:
+            return steps, usdc
+
+        conv_steps, received_usdc, price = self.convert_currency("USDT", "USDC", convert_amount)
+        for s in conv_steps:
+            logger.info(s)
+        steps.extend(conv_steps)
+        return steps, min(desired_usdc, usdc + received_usdc)
+
+    def check_pair_exists(self, ticker: str, quote: str) -> Optional[MarketInfo]:
+        return self.find_market(ticker.upper(), quote.upper())

--- a/app/logger.py
+++ b/app/logger.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+from loguru import logger
+
+
+def setup_logger(log_file: str) -> None:
+    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+    logger.remove()
+    logger.add(
+        log_file,
+        rotation="10 MB",
+        retention="14 days",
+        level="INFO",
+        format="{time:YYYY-MM-DD HH:mm:ss} | {level} | {message}",
+        enqueue=True,
+        backtrace=False,
+        diagnose=False,
+    )
+    logger.add(
+        sink=lambda msg: print(msg, end=""),
+        level="INFO",
+        format="{time:HH:mm:ss} | {level} | {message}",
+    )

--- a/bot/main.py
+++ b/bot/main.py
@@ -134,17 +134,24 @@ async def on_buy_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         # Compose result text
         result_lines = []
         result_lines.extend(steps)
-        if filled_amount > 0:
+        if settings.dry_run:
+            result_lines.append(
+                f"DRY_RUN: Купил бы {filled_amount} {ticker} по цене ~{fill_price} {used_quote}"
+            )
+            result_lines.append(
+                f"DRY_RUN: Списал бы {format_money(spent_quote, used_quote)}"
+            )
+        else:
             result_lines.append(
                 f"Куплено {filled_amount} {ticker} по цене {fill_price} {used_quote}"
             )
             result_lines.append(
                 f"Списано {format_money(spent_quote, used_quote)}"
             )
-        else:
-            result_lines.append("DRY_RUN: ордер не исполнен")
 
-        await query.edit_message_text("\n".join(result_lines))
+        text = "\n".join(result_lines)
+        logger.info(text)
+        await query.edit_message_text(text)
     except Exception as e:
         logger.exception("Ошибка в покупке")
         await query.edit_message_text(f"Ошибка: {e}")

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Optional
+
+from loguru import logger
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.ext import Application, CommandHandler, CallbackQueryHandler, ContextTypes
+
+from app.config import get_settings
+from app.logger import setup_logger
+from app.exchange import ExchangeService
+
+
+settings = get_settings()
+setup_logger(settings.log_file)
+
+
+def format_money(value: float, currency: str) -> str:
+    if currency.upper() in {"USDC", "USDT", "USD"}:
+        return f"{value:.2f} {currency.upper()}"
+    return f"{value:.8f} {currency.upper()}"
+
+
+def parse_buy_args(text: str) -> Optional[str]:
+    parts = text.strip().split()
+    if len(parts) < 2:
+        return None
+    return parts[1].upper()
+
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text("Бот готов. Используйте /buy <TICKER>")
+
+
+async def buy_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not update.message:
+        return
+    ticker = parse_buy_args(update.message.text or "")
+    if not ticker:
+        await update.message.reply_text("Формат: /buy <TICKER>")
+        return
+
+    # Offer USDC-sized buttons
+    keyboard = [
+        [
+            InlineKeyboardButton("Купить 10 USDC", callback_data=f"buy:{ticker}:10"),
+            InlineKeyboardButton("Купить 20 USDC", callback_data=f"buy:{ticker}:20"),
+        ],
+        [
+            InlineKeyboardButton("Купить 50 USDC", callback_data=f"buy:{ticker}:50"),
+            InlineKeyboardButton("Купить 100 USDC", callback_data=f"buy:{ticker}:100"),
+        ],
+    ]
+    await update.message.reply_text(
+        f"Покупка {ticker}. Выберите сумму в USDC:",
+        reply_markup=InlineKeyboardMarkup(keyboard),
+    )
+
+
+async def on_buy_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    if not query:
+        return
+    await query.answer()
+
+    _, ticker, amount_str = (query.data or "").split(":")
+    desired_usdc = float(amount_str)
+
+    exchange = ExchangeService(
+        api_key=settings.bybit_api_key,
+        secret=settings.bybit_secret,
+        dry_run=settings.dry_run,
+    )
+
+    # load markets (ccxt sync)
+    await asyncio.get_event_loop().run_in_executor(None, exchange.client.load_markets)
+
+    # STEP 1: Try TICKER/USDC
+    steps: list[str] = []
+    market_usdc = exchange.check_pair_exists(ticker, "USDC")
+    market_usdt = None
+
+    balances = exchange.get_balance()
+    usdc_balance = balances.get("USDC", 0.0)
+    usdt_balance = balances.get("USDT", 0.0)
+
+    used_quote = "USDC"
+    spent_quote = 0.0
+    fill_price = 0.0
+    filled_amount = 0.0
+
+    try:
+        if market_usdc:
+            # Ensure we have desired USDC amount, convert from USDT if needed
+            conv_steps, available_usdc = exchange.ensure_usdc_for_purchase(desired_usdc)
+            steps.extend(conv_steps)
+            if available_usdc < desired_usdc:
+                await query.edit_message_text(
+                    f"Недостаточно средств (баланс USDC/USDT: {format_money(usdc_balance, 'USDC')} / {format_money(usdt_balance, 'USDT')})"
+                )
+                return
+
+            order, amount, price = exchange.market_buy_by_quote(market_usdc, desired_usdc)
+            used_quote = "USDC"
+            spent_quote = desired_usdc
+            fill_price = price
+            filled_amount = amount
+        else:
+            # Fallback to USDT pair
+            market_usdt = exchange.check_pair_exists(ticker, "USDT")
+            if not market_usdt:
+                await query.edit_message_text(
+                    f"Пара {ticker}/USDC и {ticker}/USDT не найдены на Bybit"
+                )
+                return
+
+            # Ensure we have USDT by converting USDC if needed
+            conv_steps, available_for_usdt = exchange.ensure_usdt_for_purchase(desired_usdc)
+            steps.extend(conv_steps)
+            if available_for_usdt < desired_usdc:
+                await query.edit_message_text(
+                    f"Недостаточно средств (баланс USDC/USDT: {format_money(usdc_balance, 'USDC')} / {format_money(usdt_balance, 'USDT')})"
+                )
+                return
+
+            order, amount, price = exchange.market_buy_by_quote(market_usdt, desired_usdc)
+            used_quote = "USDT"
+            spent_quote = desired_usdc
+            fill_price = price
+            filled_amount = amount
+
+        # Compose result text
+        result_lines = []
+        result_lines.extend(steps)
+        if filled_amount > 0:
+            result_lines.append(
+                f"Куплено {filled_amount} {ticker} по цене {fill_price} {used_quote}"
+            )
+            result_lines.append(
+                f"Списано {format_money(spent_quote, used_quote)}"
+            )
+        else:
+            result_lines.append("DRY_RUN: ордер не исполнен")
+
+        await query.edit_message_text("\n".join(result_lines))
+    except Exception as e:
+        logger.exception("Ошибка в покупке")
+        await query.edit_message_text(f"Ошибка: {e}")
+
+
+async def run() -> None:
+    token = settings.telegram_token
+    if not token:
+        logger.error("TELEGRAM_TOKEN не задан в .env")
+        return
+
+    app = Application.builder().token(token).build()
+
+    app.add_handler(CommandHandler("start", start))
+    app.add_handler(CommandHandler("buy", buy_cmd))
+    app.add_handler(CallbackQueryHandler(on_buy_callback, pattern=r"^buy:"))
+
+    logger.info("Бот запущен")
+    await app.run_polling()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(run())
+    except KeyboardInterrupt:
+        pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+python-telegram-bot==20.7
+ccxt==4.4.75
+python-dotenv==1.0.1
+loguru==0.7.2


### PR DESCRIPTION
Implement USDC as the primary base currency for `/buy` commands, with automatic conversion to USDT when a direct USDC pair is unavailable, to enhance trading flexibility.

This update allows the bot to prioritize USDC for purchases, automatically converting USDC to USDT if a direct `<TICKER>/USDC` pair is not found but a `<TICKER>/USDT` pair is available. It includes detailed logging of conversion steps and final trade details, and supports the existing DRY_RUN mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-703845ac-6318-47c8-be50-0d9a4d3bf374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-703845ac-6318-47c8-be50-0d9a4d3bf374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

